### PR TITLE
chore: ignore local tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ coverage/
 *.log
 
 # Local tooling
+.agent/
 .agents/
 .claude/
+.codex/
 skills-lock.json


### PR DESCRIPTION
## Summary
- `.agent/`, `.codex/` 디렉토리를 `.gitignore`에 추가
- 로컬 툴링 파일(Codex, Claude Code, Speckits 등)이 실수로 커밋되는 것을 방지