### PR TITLE
chore: add issue templates for all branch types

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,24 @@
+name: "🔧 유지보수"
+description: 의존성 업데이트, 설정 변경, 도구 관련 작업입니다
+labels: ["chore"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 작업 내용
+      description: 어떤 유지보수 작업이 필요한가요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 이유 / 배경
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 영향 범위 (선택)
+      description: 이 작업이 다른 기능에 영향을 줄 수 있나요?

--- a/.github/ISSUE_TEMPLATE/ci.yml
+++ b/.github/ISSUE_TEMPLATE/ci.yml
@@ -1,0 +1,24 @@
+name: "⚙️ CI/CD"
+description: GitHub Actions 또는 배포 파이프라인 관련 작업입니다
+labels: ["ci"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 작업 내용
+      description: 어떤 CI/CD 변경이 필요한가요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 이유 / 배경
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: 배포 영향 (선택)
+      description: 파이프라인 변경으로 인한 배포 영향이 있다면 적어주세요

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,25 @@
+name: "📝 문서"
+description: 문서 추가 또는 수정을 제안합니다
+labels: ["docs"]
+body:
+  - type: textarea
+    id: target
+    attributes:
+      label: 대상 문서
+      description: 어떤 문서를 추가하거나 수정해야 하나요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: 수정 이유
+      description: 왜 변경이 필요한가요? (누락, 오류, 구버전 등)
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 변경 내용 (선택)
+      description: 구체적인 변경 내용이 있다면 적어주세요

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -1,0 +1,31 @@
+name: "✨ 기능 요청"
+description: 새로운 기능을 제안합니다
+labels: ["feat"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 기능 요약
+      description: 어떤 기능이 필요한지 간략히 설명해주세요
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 배경 및 동기
+      description: 왜 이 기능이 필요한가요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 구현 방향 (선택)
+      description: 구체적인 구현 아이디어가 있다면 적어주세요
+
+  - type: textarea
+    id: related
+    attributes:
+      label: 관련 이슈 / 문서
+      description: 참고할 이슈, PR, 문서 링크가 있다면 적어주세요

--- a/.github/ISSUE_TEMPLATE/fix.yml
+++ b/.github/ISSUE_TEMPLATE/fix.yml
@@ -1,0 +1,51 @@
+name: "🐛 버그 리포트"
+description: 버그를 제보합니다
+labels: ["fix"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 버그 설명
+      description: 어떤 문제가 발생했나요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 방법
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 예상 동작
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 실제 동작
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 환경
+      placeholder: |
+        - Node.js 버전:
+        - OS:
+        - 기타:
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 로그 / 스크린샷 (선택)
+      description: 관련 오류 로그나 스크린샷을 첨부해주세요

--- a/.github/ISSUE_TEMPLATE/hotfix.yml
+++ b/.github/ISSUE_TEMPLATE/hotfix.yml
@@ -1,0 +1,37 @@
+name: "🚨 긴급 수정"
+description: 프로덕션 긴급 수정이 필요한 이슈를 제보합니다
+labels: ["hotfix"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **주의:** hotfix 브랜치는 `main`에서 직접 분기하고, 완료 후 `main`과 `develop` **양쪽**에 PR을 올려야 합니다.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 문제 설명
+      description: 프로덕션에서 발생한 문제를 설명해주세요
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: 영향 범위
+      description: 어떤 기능/사용자에게 영향을 미치고 있나요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 방법
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_fix
+    attributes:
+      label: 수정 방향 (선택)
+      description: 빠른 수정 방향이 있다면 적어주세요

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,36 @@
+name: "♻️ 리팩토링"
+description: 기능 변경 없이 코드 구조를 개선합니다
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: target
+    attributes:
+      label: 대상 코드
+      description: 어떤 파일이나 모듈을 개선할 예정인가요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 현재 문제점
+      description: 왜 개선이 필요한가요?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 개선 방향
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: 확인 사항
+      options:
+        - label: 외부 동작(API, 응답 포맷 등)을 변경하지 않습니다
+          required: true
+        - label: 기존 테스트가 모두 통과합니다
+          required: true


### PR DESCRIPTION
## 개요

브랜치 타입별 GitHub 이슈 템플릿 7종 추가

## 브랜치 타입

- [x] `chore/` – 의존성·설정·도구 관련

## 체크리스트

- [x] 대상 브랜치가 올바른가?
- [x] 테스트를 추가하거나 기존 테스트가 통과하는가?
- [x] 관련 문서를 업데이트했는가?