### PR TITLE
[DOCS] PR 제목 형식 및 이슈 자동 닫힘 규칙 추가

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
+<!-- PR 제목 형식: [TYPE] 작업 제목 -->
+<!-- 예시: [FEAT] Amplitude Adapter 구현, [FIX] Discord 전송 재시도 오류 수정 -->
+<!-- TYPE: FEAT · FIX · HOTFIX · REFACTOR · DOCS · TEST · CHORE · CI -->
+
 ## 관련 이슈
 
-<!-- 연결된 이슈 번호를 적어주세요 -->
 closes #
 
 ## 개요
@@ -27,6 +30,7 @@ closes #
 
 ## 체크리스트
 
+- [ ] PR 제목이 `[TYPE] 작업 제목` 형식인가?
 - [ ] 브랜치 이름이 `{type}/#{issue_number}` 형식인가?
 - [ ] 대상 브랜치가 올바른가? (`hotfix` 제외 → `develop`, `hotfix` → `main` + `develop`)
 - [ ] 테스트를 추가하거나 기존 테스트가 통과하는가?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,20 @@ AI 계층 (bounded tool calling, Phase 8, AI_ENABLED=false)
 
 타입 목록: `feat` · `fix` · `hotfix` · `refactor` · `docs` · `test` · `chore` · `ci`
 
+### PR 제목
+
+```text
+[TYPE] 작업 제목
+```
+
+예시: `[FEAT] Amplitude Adapter 구현`, `[FIX] Discord 전송 재시도 오류 수정`
+
+타입 대문자 매핑: `feat`→`FEAT` · `fix`→`FIX` · `hotfix`→`HOTFIX` · `refactor`→`REFACTOR` · `docs`→`DOCS` · `test`→`TEST` · `chore`→`CHORE` · `ci`→`CI`
+
+### 이슈 연결
+
+PR 본문 **관련 이슈** 섹션에 `closes #이슈번호` 를 기입하면 PR 머지 시 해당 이슈가 자동으로 닫힌다.
+
 ### 이슈 구조
 
 - **메인 이슈**: Phase 단위 또는 대형 기능 단위로 생성


### PR DESCRIPTION
## 관련 이슈

closes #13

## 개요

PR 제목을 `[TYPE] 작업 제목` 형식으로 통일하고, `closes #` 키워드를 PR 템플릿에 명시하여 머지 시 이슈가 자동으로 닫히도록 규칙을 추가한다.

## 설계 판단

PR 제목에 타입을 대문자로 명시하면 GitHub 이슈/PR 목록에서 한눈에 작업 성격을 파악할 수 있다. `closes #`는 템플릿에 고정하여 누락을 방지한다.

## 브랜치 타입

- [x] `docs/` – 문서 작성·수정

## 체크리스트

- [x] PR 제목이 `[TYPE] 작업 제목` 형식인가?
- [x] 브랜치 이름이 `{type}/#{issue_number}` 형식인가?
- [x] 대상 브랜치가 올바른가? (`develop`)
- [x] 테스트를 추가하거나 기존 테스트가 통과하는가? (문서 변경만)
- [x] 관련 문서를 업데이트했는가?